### PR TITLE
app: add new translations for Spanish locales

### DIFF
--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -8,4 +8,8 @@
     <string name="build_number_title">Número de compilación</string>
     <string name="knox_version_title">Versión de Knox</string>
     <string name="knox_features_title">Características de Knox</string>
+
+    <string name="sep_12_crypto_warning_dialog_title">Tu partición "data" está encriptada</string>
+    <string name="sep_12_crypto_warning_dialog_message">Esta app ha detectado que dicha partición en tu dispositivo está encriptada, por lo que Carpeta Segura podría no funcionar correctamente.</string>
+    <string name="sep_12_crypto_warning_dialog_btn">Entiendo</string>
 </resources>

--- a/app/src/main/res/values-es-rUS/strings.xml
+++ b/app/src/main/res/values-es-rUS/strings.xml
@@ -8,4 +8,8 @@
     <string name="build_number_title">Número de compilación</string>
     <string name="knox_version_title">Versión de Knox</string>
     <string name="knox_features_title">Características de Knox</string>
+
+    <string name="sep_12_crypto_warning_dialog_title">Tu partición "data" está encriptada</string>
+    <string name="sep_12_crypto_warning_dialog_message">Esta app ha detectado que dicha partición en tu dispositivo está encriptada, por lo que Carpeta Segura podría no funcionar correctamente.</string>
+    <string name="sep_12_crypto_warning_dialog_btn">Entiendo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,21 +1,24 @@
 <resources>
+    <!--Non-translatable-->
     <string name="app_name" translatable="false">KnoxPatch</string>
-    <string name="module_description">Get Knox features working again in your rooted Samsung Galaxy device.</string>
-
     <string name="github" translatable="false">GitHub</string>
 
-    <string name="app_info">App info</string>
-    <string name="oneui_version_title">One UI version</string>
-    <string name="oneui_version_title_seplite">One UI core</string>
-    <string name="android_version_title">Android version</string>
-    <string name="build_number_title">Build number</string>
-    <string name="knox_version_title">Knox version</string>
     <string name="knox_version_knox" translatable="false">Knox</string>
     <string name="knox_version_knox_api" translatable="false">Knox API level</string>
     <string name="knox_version_knox_tima" translatable="false">TIMA</string>
     <string name="knox_version_knox_ml" translatable="false">Knox ML</string>
     <string name="knox_version_knox_dualdar" translatable="false">DualDAR</string>
     <string name="knox_version_knox_hdm" translatable="false">HDM</string>
+
+    <!--Translatable-->
+    <string name="module_description">Get Knox features working again in your rooted Samsung Galaxy device.</string>
+
+    <string name="app_info">App info</string>
+    <string name="oneui_version_title">One UI version</string>
+    <string name="oneui_version_title_seplite">One UI Core version</string>
+    <string name="android_version_title">Android version</string>
+    <string name="build_number_title">Build number</string>
+    <string name="knox_version_title">Knox version</string>
     <string name="knox_features_title">Knox features</string>
 
     <string name="sep_12_crypto_warning_dialog_title">Your data partition is encrypted</string>


### PR DESCRIPTION
This commit also reorders source strings in translatable and non-translatable, so that translators can track more easily which strings need to be translated.