### PR TITLE
app: hooks: MainHook: hook SamsungKeystoreHooks to Quick Share app

### DIFF
--- a/app/src/main/java/io/mesalabs/knoxpatch/MainHook.kt
+++ b/app/src/main/java/io/mesalabs/knoxpatch/MainHook.kt
@@ -87,7 +87,11 @@ object MainHook : IYukiHookXposedInit {
             loadApp(Constants.SAMSUNG_CLOUD_PACKAGE_NAME, SamsungKeystoreHooks)
             loadApp(Constants.SAMSUNG_WALLET_PACKAGE_NAME, SamsungKeystoreHooks)
             loadApp(Constants.SECURE_WIFI_PACKAGE_NAME, SamsungKeystoreHooks)
-            loadApp(Constants.PRIVATE_SHARE_PACKAGE_NAME, SamsungKeystoreHooks)
+            if (sepVersion >= Constants.ONEUI_5_1_1) {
+                loadApp(Constants.QUICK_SHARE_PACKAGE_NAME, SamsungKeystoreHooks)
+            } else {
+                loadApp(Constants.PRIVATE_SHARE_PACKAGE_NAME, SamsungKeystoreHooks)
+            }
         }
 
         loadApp(Constants.SAMSUNG_HEALTH_PACKAGE_NAME, SamsungHealthHooks)

--- a/app/src/main/java/io/mesalabs/knoxpatch/utils/Constants.kt
+++ b/app/src/main/java/io/mesalabs/knoxpatch/utils/Constants.kt
@@ -84,6 +84,7 @@ object Constants {
     const val SAMSUNG_HEALTH_PACKAGE_NAME: String = "com.sec.android.app.shealth"
     const val SAMSUNG_HEALTH_MONITOR_PACKAGE_NAME: String = "com.samsung.android.shealthmonitor"
     const val SAMSUNG_WALLET_PACKAGE_NAME: String = "com.samsung.android.spay"
+    const val QUICK_SHARE_PACKAGE_NAME: String = "com.samsung.android.app.sharelive"
     const val SECURE_FOLDER_PACKAGE_NAME: String = "com.samsung.knox.securefolder"
     const val SECURE_WIFI_PACKAGE_NAME: String = "com.samsung.android.fast"
 

--- a/app/src/main/res/values-v33/arrays.xml
+++ b/app/src/main/res/values-v33/arrays.xml
@@ -3,6 +3,7 @@
     <string-array name="scope">
         <item>android</item>
         <item>com.osp.app.signin</item>
+        <item>com.samsung.android.app.sharelive</item>
         <item>com.samsung.android.fast</item>
         <item>com.samsung.android.fmm</item>
         <item>com.samsung.android.galaxycontinuity</item>


### PR DESCRIPTION
This should fix Private Share for One UI 5.1.1 and above.